### PR TITLE
fix: 艾特全体成员时返回友好提示而非报错

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,6 +122,10 @@ class Relationship(Star):
         画像 @群友 <查询轮数>
         """
         target_id: str = await self.get_at_id(event) or event.get_sender_id()
+        # 当画像at全体成员时，target_id为"all"
+        if target_id == "all":
+            yield event.plain_result("不能At全体成员")
+            return
         nickname, gender = await self.get_nickname(event, target_id)
         contexts, query_rounds = None, None
         if self.contexts_cache and target_id in self.contexts_cache:


### PR DESCRIPTION
当  target_id == "all"  时，主动提示并提前 return，避免后续逻辑抛出异常。

## Sourcery 总结

错误修复：
- 添加对 `target_id == "all"` 的检查，以返回一个普通结果消息，而不是让后续逻辑抛出错误

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a check for target_id == "all" to yield a plain-result message instead of letting later logic throw an error

</details>