### PR TITLE
feat: 可选服务商

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -21,6 +21,13 @@
         },
         "default": 20
     },
+    "provider_id": {
+        "description": "用于分析画像的LLM提供商",
+        "hint": "留空或者填写的提供商不存在时，则使用当前正在使用的LLM提供商",
+        "type": "string",
+        "default": "",
+        "_special": "select_provider"
+    },
     "system_prompt_template": {
         "description": "系统提示词模板",
         "type": "text",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_portrayal
 display_name: 人物画像
 desc: 爬取群友的聊天记录，进而用llm分析群友画像
 help: 略
-version: v1.0.5
+version: v1.0.6
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_portrayal


### PR DESCRIPTION
## Summary by Sourcery

优化用于人物画像分析的用户消息收集方式，并新增可配置的 LLM 提供商选择机制及更安全的回退策略。

New Features:
- 允许通过可配置的 `provider_id` 选择 LLM 提供商，并在未配置或无效时回退到当前默认提供商。

Enhancements:
- 将缓存的用户聊天记录从 OpenAI 风格的上下文对象改为纯文本消息，以便在人物画像分析中复用。
- 调整人物画像生成的 LLM 提示词，改为使用基于用户历史消息整理的、有序且以分析为中心的文本。
- 改进在没有可用的有效 LLM 提供商时的错误处理逻辑，用于文本生成的失败场景。
- 将插件元数据版本提升至 v1.0.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine user message collection for persona analysis and add configurable LLM provider selection with a safer fallback.

New Features:
- Allow selecting the LLM provider via a configurable provider_id with fallback to the current default provider.

Enhancements:
- Change cached user chat history from OpenAI-style context objects to plain text messages for reuse in persona analysis.
- Revise the LLM prompt for persona generation to use ordered, analysis-focused text derived from the user’s historical messages.
- Improve error handling when no valid LLM provider is available for text generation.
- Bump plugin metadata version to v1.0.6.

</details>

增强内容：
- 优化消息历史处理方式，将按用户缓存和复用的内容改为纯文本消息，而不是类似 OpenAI 风格的上下文对象。
- 改进用于用户画像的 LLM 提示词，将收集到的消息转换为有序、以分析为中心的文本块。
- 增加通过可配置的 `provider_id` 选择 LLM 提供商的支持，并在未指定时回退到默认提供商。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化用于人物画像分析的用户消息收集方式，并新增可配置的 LLM 提供商选择机制及更安全的回退策略。

New Features:
- 允许通过可配置的 `provider_id` 选择 LLM 提供商，并在未配置或无效时回退到当前默认提供商。

Enhancements:
- 将缓存的用户聊天记录从 OpenAI 风格的上下文对象改为纯文本消息，以便在人物画像分析中复用。
- 调整人物画像生成的 LLM 提示词，改为使用基于用户历史消息整理的、有序且以分析为中心的文本。
- 改进在没有可用的有效 LLM 提供商时的错误处理逻辑，用于文本生成的失败场景。
- 将插件元数据版本提升至 v1.0.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine user message collection for persona analysis and add configurable LLM provider selection with a safer fallback.

New Features:
- Allow selecting the LLM provider via a configurable provider_id with fallback to the current default provider.

Enhancements:
- Change cached user chat history from OpenAI-style context objects to plain text messages for reuse in persona analysis.
- Revise the LLM prompt for persona generation to use ordered, analysis-focused text derived from the user’s historical messages.
- Improve error handling when no valid LLM provider is available for text generation.
- Bump plugin metadata version to v1.0.6.

</details>

</details>