### PR TITLE
fix: 由于在缓存中的message_seq消息被撤回后，通过cq接口查询指定消息报错

### DIFF
--- a/core/message.py
+++ b/core/message.py
@@ -80,6 +80,7 @@ class MessageManager:
 
         if time() - cached.timestamp > self.cfg.cache_ttl:
             del self._user_cache[key]
+            del self._group_cursor[group_id]
             return None
 
         return cached.texts
@@ -167,27 +168,28 @@ class MessageManager:
                     count=self.cfg.per_query_count,
                     reverseOrder=True,
                 )
+
+                messages = result.get("messages", [])
+                if not messages:
+                    break
+
+                # 更新群扫描断点
+                message_seq = messages[0]["message_id"]
+                self._group_cursor[group_id] = message_seq
+
+                # 关键点：这一页给所有人缓存
+                self._collect_messages(group_id, messages)
+
+                # 再取目标用户
+                cached = self._get_user_cache(group_id, target_id)
+                if cached:
+                    texts = cached[:]
+
             except Exception as e:
                 logger.error(e)
-                # 这里查询的消息可能已经被撤回了，重置序号
+                # 这里查询的消息可能不存在，重置序号
                 message_seq = 0
-                continue
-
-            messages = result.get("messages", [])
-            if not messages:
-                break
-
-            # 更新群扫描断点
-            message_seq = messages[0]["message_id"]
-            self._group_cursor[group_id] = message_seq
-
-            # 关键点：这一页给所有人缓存
-            self._collect_messages(group_id, messages)
-
-            # 再取目标用户
-            cached = self._get_user_cache(group_id, target_id)
-            if cached:
-                texts = cached[:]
+                self.clear_cache()
 
             rounds += 1
 


### PR DESCRIPTION
## Summary by Sourcery

在查询群聊历史消息时，处理缺失或无效的已缓存群消息序列，以防止错误并安全地重置状态。

Bug 修复：
- 当由于消息缺失导致已缓存的群消息查询失败时，重置群游标和用户缓存。
- 当用户缓存条目过期时，清除过期的群游标，以避免使用无效的消息序列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing or invalid cached group message sequences when querying group message history to prevent errors and reset state safely.

Bug Fixes:
- Reset group cursor and user cache when cached group message queries fail due to missing messages.
- Clear stale group cursors when user cache entries expire to avoid using invalid message sequences.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在查询群聊历史消息时，处理缺失或无效的已缓存群消息序列，以防止错误并安全地重置状态。

Bug 修复：
- 当由于消息缺失导致已缓存的群消息查询失败时，重置群游标和用户缓存。
- 当用户缓存条目过期时，清除过期的群游标，以避免使用无效的消息序列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing or invalid cached group message sequences when querying group message history to prevent errors and reset state safely.

Bug Fixes:
- Reset group cursor and user cache when cached group message queries fail due to missing messages.
- Clear stale group cursors when user cache entries expire to avoid using invalid message sequences.

</details>

</details>