### PR TITLE
fix: 减少无意义的网络请求

### DIFF
--- a/core/message.py
+++ b/core/message.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from time import time
+from typing import Any
+
+from astrbot.api import logger
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+    AiocqhttpMessageEvent,
+)
+
+from .config import PluginConfig
+from .message_cache import CachedMessages, MessageCacheStorage
+
+
+@dataclass
+class MessageQueryResult:
+    """Store collected messages and query metadata."""
+
+    texts: list[str]
+    scanned_messages: int
+    from_cache: bool
+
+    @property
+    def count(self) -> int:
+        return len(self.texts)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.texts
+
+
+# =========================
+# message manager
+# =========================
+
+
+class MessageManager:
+    """Manage group-level scans and per-user message caches.
+
+    Queries in the same group share scan progress. Each scanned page caches
+    messages for every user, and later queries continue from the group cursor.
+    """
+
+    def __init__(self, config: PluginConfig):
+        self.cfg = config.message
+        self._storage = MessageCacheStorage(config.cache_dir)
+
+        # user cache: group:user -> messages
+        self._user_cache, self._group_cursor = self._storage.load()
+
+        # group cursor: group -> message_seq
+        # group lock: serialize history scans within the same group
+        self._group_locks: dict[str, asyncio.Lock] = {}
+
+    # =========================
+    # cache helpers
+    # =========================
+
+    def _user_key(self, group_id: str, user_id: str) -> str:
+        return f"{group_id}:{user_id}"
+
+    def _get_user_cache(self, group_id: str, user_id: str) -> list[str] | None:
+        key = self._user_key(group_id, user_id)
+        cached = self._user_cache.get(key)
+        if not cached:
+            return None
+
+        if time() - cached.timestamp > self.cfg.cache_ttl:
+            self._group_cursor.pop(group_id, None)
+            for group_user_key in tuple(self._user_cache):
+                if group_user_key.startswith(f"{group_id}:"):
+                    del self._user_cache[group_user_key]
+            self.save_cache()
+            return None
+
+        return cached.texts
+
+    def clear_cache(self):
+        self._user_cache.clear()
+        self._group_cursor.clear()
+        self._storage.clear()
+
+    def save_cache(self) -> None:
+        """Persist the current in-memory message cache."""
+        self._storage.save(self._user_cache, self._group_cursor)
+
+    # =========================
+    # message parsing
+    # =========================
+
+    def _collect_messages(
+        self,
+        group_id: str,
+        messages: list[dict[str, Any]],
+    ):
+        """Cache one page of group messages by user."""
+        now = time()
+
+        for msg in messages:
+            user_id = str(msg["sender"]["user_id"])
+
+            text = "".join(
+                seg["data"]["text"] for seg in msg["message"] if seg["type"] == "text"
+            ).strip()
+
+            if not text:
+                continue
+
+            key = self._user_key(group_id, user_id)
+            cached = self._user_cache.get(key)
+
+            if not cached:
+                self._user_cache[key] = CachedMessages(
+                    texts=[text],
+                    timestamp=now,
+                )
+            else:
+                cached.texts.append(text)
+                cached.timestamp = now
+
+    # =========================
+    # public api
+    # =========================
+
+    async def get_user_texts(
+        self,
+        event: AiocqhttpMessageEvent,
+        target_id: str,
+        *,
+        max_rounds: int,
+    ) -> MessageQueryResult:
+        """Get the target user history from the current group.
+
+        Args:
+            event: Current group message event.
+            target_id: Target user ID.
+            max_rounds: Maximum number of history pages to query.
+
+        Returns:
+            The collected texts and query metadata.
+        """
+        group_id = str(event.get_group_id())
+        target_id = str(target_id)
+
+        # ---------- cache first ----------
+        cached = self._get_user_cache(group_id, target_id)
+        if cached and (len(cached) >= self.cfg.max_msg_count or (len(cached) > 0 and time() - self._user_cache[self._user_key(group_id, target_id)].timestamp < self.cfg.cache_ttl / 2)):
+            return MessageQueryResult(
+                texts=cached[: self.cfg.max_msg_count],
+                scanned_messages=0,
+                from_cache=True,
+            )
+
+        texts = cached[:] if cached else []
+        rounds = 0
+        cache_changed = False
+
+        # Resume from the shared group scan cursor.
+        message_seq = self._group_cursor.get(group_id, 0)
+        group_lock = self._group_locks.setdefault(group_id, asyncio.Lock())
+
+        # ---------- scan group messages ----------
+        while rounds < max_rounds and len(texts) < self.cfg.max_msg_count:
+            try:
+                # message_seq is a message ID, not an offset.
+                async with group_lock:
+                    cached = self._get_user_cache(group_id, target_id)
+                    if cached and len(cached) >= self.cfg.max_msg_count:
+                        texts = cached[:]
+                        break
+
+                    message_seq = self._group_cursor.get(group_id, 0)
+                    result: dict[str, Any] = await event.bot.api.call_action(
+                        "get_group_msg_history",
+                        group_id=group_id,
+                        message_seq=message_seq,
+                        count=self.cfg.per_query_count,
+                        reverseOrder=True,
+                    )
+                    messages = result.get("messages", [])
+                    if messages:
+                        message_seq = messages[0]["message_id"]
+                        self._group_cursor[group_id] = message_seq
+                        self._collect_messages(group_id, messages)
+                        cache_changed = True
+
+                messages = result.get("messages", [])
+                if not messages:
+                    break
+
+                # Refresh the target cache after collecting the page.
+                cached = self._get_user_cache(group_id, target_id)
+                if cached:
+                    texts = cached[:]
+
+            except Exception as e:
+                logger.error(e)
+                break
+
+            rounds += 1
+
+        if cache_changed:
+            self.save_cache()
+
+        return MessageQueryResult(
+            texts=texts[: self.cfg.max_msg_count],
+            scanned_messages=rounds * self.cfg.per_query_count,
+            from_cache=cached is not None,
+        )


### PR DESCRIPTION
根据 issue #35 的反馈，优化了 get_user_texts 的缓存策略。现在即使缓存未达标，只要在 TTL 的半程窗口内且非空，即优先返回缓存，减少对 API 的强制轮询。

## Summary by Sourcery

引入消息管理器，用于集中管理按用户分组的消息缓存与检索，优化历史扫描并减少冗余的网络请求。

Bug Fixes:
- 调整用户消息检索逻辑，在 TTL 时间窗口内优先使用有效的近期缓存条目，从而减少对 `get_group_msg_history` 的不必要 API 轮询。

Enhancements:
- 添加 `MessageManager` 和 `MessageQueryResult` 抽象，用于管理群组级别的扫描游标以及基于持久化存储的每用户文本缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a message manager to centralize per-user group message caching and retrieval, optimizing history scans and reducing redundant network requests.

Bug Fixes:
- Adjust user message retrieval logic to favor valid recent cache entries within a TTL window, reducing unnecessary API polling for get_group_msg_history.

Enhancements:
- Add MessageManager and MessageQueryResult abstractions to manage group-level scan cursors and per-user text caches backed by persistent storage.

</details>